### PR TITLE
Bugfix: missing valid API key

### DIFF
--- a/malsub/core/main.py
+++ b/malsub/core/main.py
@@ -128,7 +128,7 @@ def run(arg, usage):
                     out.error(f"service \"{anserv[n].name}\" missing a valid API key \"{k}\"")
                 elif k.get("apikey") == "":
                     out.error(f"service \"{anserv[n].name}\" missing a valid API key \"{k}\"")
-                elif k.get("apikey").get("apikey") == "<apikey>":
+                elif k.get("apikey").get("api_key") == "<apikey>":
                     out.error(f"service \"{anserv[n].name}\" missing a valid API key \"{k}\"")
                 else:
                     anserv[n].set_apikey(k)

--- a/malsub/core/main.py
+++ b/malsub/core/main.py
@@ -122,10 +122,14 @@ def run(arg, usage):
             out.error(f"cannot load API keys file \"{meta.APIKEY_PATH}\": {e}")
         else:
             for n, k in apikey.items():
-                if type(k) is not dict or \
-                  k.get("apikey") is None or k.get("apikey") == "":
-                    out.error(f"service \"{anserv[n].name}\" missing "
-                              f"a valid API key \"{k}\"")
+                if type(k) is not dict:
+                    out.error(f"service \"{anserv[n].name}\" missing a valid API key \"{k}\"")
+                elif k.get("apikey") is None:
+                    out.error(f"service \"{anserv[n].name}\" missing a valid API key \"{k}\"")
+                elif k.get("apikey") == "":
+                    out.error(f"service \"{anserv[n].name}\" missing a valid API key \"{k}\"")
+                elif k.get("apikey").get("apikey") == "<apikey>":
+                    out.error(f"service \"{anserv[n].name}\" missing a valid API key \"{k}\"")
                 else:
                     anserv[n].set_apikey(k)
             out.debug("apikey", obj=apikey)

--- a/malsub/service/avcaesar.py
+++ b/malsub/service/avcaesar.py
@@ -1,6 +1,6 @@
 from malsub.service.base import APISpec, Service
 from malsub.core.type import File, Hash
-from malsub.core.web import request, openurl
+from malsub.core.web import request
 from malsub.common import out, rw, frmt
 
 
@@ -10,7 +10,7 @@ class AVCaesar(Service):
     api_keyl = 64
 
     desc = f"{name} is an online sandbox and malware repository developed under\n" \
-           f"a project from European Comission and maintained by a CERT in\n" \
+           f"a project from European Commission and maintained by a CERT in\n" \
            f"Luxembourg"
     subs = "public"
     url = "https://avcaesar.malware.lu/"


### PR DESCRIPTION
Malsub now correctly exits if a requested service is missing a valid API key