### PR TITLE
Improve verbosity level control and add a flag for ouput folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ The main goal of *malsub* is to serve as a one-stop-shop for querying multiple o
 The supported options are the following:
 
 ```
-Usage: malsub [-h] [-a <service>] [-H] [-p <num>] [-R] [-v ...]
-              [-d | -f | -q | -r | -s | -t]
+Usage: malsub [-h] [-a <service>] [-H] [-p <num>] [-R] [-v <level>]
+              [-d | -f | -q | -r | -s | -t] [-O <dir>]
               [-i | -o | -l | -u]
               [<input> ...]
 
@@ -64,18 +64,19 @@ Options:
   -h, --help  show this help message and exit
 
   -a, --analysis <service>  character-separated list of services (class or short names) [default: all]
-  -H, --servhelp     show help messages about selected services and exit
-  -p, --pause <num>  wait an interval in seconds between service requests (rate limit) [default: 0]
-  -R, --recursive    recurse on input paths
-  -v, --verbose      display verbose and debug messages
+  -H, --servhelp          show help messages about selected services and exit
+  -p, --pause <num>       wait an interval in seconds between service requests (rate limit) [default: 0]
+  -R, --recursive         recurse on input paths
+  -v, --verbose=<level>   choose verbosity level (0: Quiet, 1: Info, 2: Verbose, 3: Debug) [default: 1]
 
 API functions:
-  -d, --download  download files or malware samples
-  -f, --find      search for arbitrary terms (input format irrelevant)
-  -q, --quota     retrieve API user quota
-  -r, --report    retrieve submission reports for domains, files, hash values, IP addresses or URLs
-  -s, --submit    submit malware samples or URLs for analysis
-  -t, --test      test API calls by calling each service function as defined with some default values
+  -d, --download       download files or malware samples
+  -f, --find           search for arbitrary terms (input format irrelevant)
+  -O, --output=<dir>   directory in which to save the file
+  -q, --quota          retrieve API user quota
+  -r, --report         retrieve submission reports for domains, files, hash values, IP addresses or URLs
+  -s, --submit         submit malware samples or URLs for analysis
+  -t, --test           test API calls by calling each service function as defined with some default values
 
 Input formats (hash values or files are given as default depending on options):
   -i, --ipaddr  input are IPv4 addresses (applies to '-r' only)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ class VirusTotal(Service):
     # '@Service.unsupported' marks a function as unsupported by a particular
     # service, being ignored by the main application
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         # all base functions need to be explicitly declared even if not used by
         # a service
         pass

--- a/malsub.py
+++ b/malsub.py
@@ -12,11 +12,11 @@ samples, domain names, IP addresses or URLs.
 Options:
   -h, --help  show this help message and exit
 
-  -a, --analysis <service>  character-separated list of services (class or short names) [default: all]
-  -H, --servhelp     show help messages about selected services and exit
-  -p, --pause <num>  wait an interval in seconds between service requests (rate limit) [default: 0]
-  -R, --recursive    recurse on input paths
-  -v, --verbose      display verbose and debug messages
+  -a, --analysis <service>    character-separated list of services (class or short names) [default: all]
+  -H, --servhelp              show help messages about selected services and exit
+  -p, --pause <num>           wait an interval in seconds between service requests (rate limit) [default: 0]
+  -R, --recursive             recurse on input paths
+  -v, --verbose=<level>       choose verbosity level (0: Quiet, 1: Info, 2: Verbose, 3: Debug) [default: 1]
 
 API functions:
   -d, --download  download files or malware samples

--- a/malsub.py
+++ b/malsub.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 """
-Usage: malsub [-h] [-a <service>] [-H] [-p <num>] [-R] [-v ...]
-              [-d | -f | -q | -r | -s | -t]
+Usage: malsub [-h] [-a <service>] [-H] [-p <num>] [-R] [-v <level>]
+              [-d | -f | -q | -r | -s | -t] [-O <dir>]
               [-i | -o | -l | -u]
               [<input> ...]
 
@@ -19,12 +19,13 @@ Options:
   -v, --verbose=<level>       choose verbosity level (0: Quiet, 1: Info, 2: Verbose, 3: Debug) [default: 1]
 
 API functions:
-  -d, --download  download files or malware samples
-  -f, --find      search for arbitrary terms (input format irrelevant)
-  -q, --quota     retrieve API user quota
-  -r, --report    retrieve submission reports for domains, files, hash values, IP addresses or URLs
-  -s, --submit    submit malware samples or URLs for analysis
-  -t, --test      test API calls by calling each service function as defined with some default values
+  -d, --download       download files or malware samples
+  -f, --find           search for arbitrary terms (input format irrelevant)
+  -O, --output=<dir>   directory in which to save the file
+  -q, --quota          retrieve API user quota
+  -r, --report         retrieve submission reports for domains, files, hash values, IP addresses or URLs
+  -s, --submit         submit malware samples or URLs for analysis
+  -t, --test           test API calls by calling each service function as defined with some default values
 
 Input formats (hash values or files are given as default depending on options):
   -i, --ipaddr  input are IPv4 addresses (applies to '-r' only)

--- a/malsub/common/out.py
+++ b/malsub/common/out.py
@@ -13,6 +13,7 @@ class log:
 
     input = "input"
 
+    quiet = "quiet"
     debug = "debug"
     verb = "verbose"
     info = "info"

--- a/malsub/common/rw.py
+++ b/malsub/common/rw.py
@@ -1,6 +1,6 @@
 from malsub.common import out
 from malsub.core.meta import DOWNL_PATH
-
+import os
 
 def validff(file):
     for f in file:
@@ -41,7 +41,16 @@ def closef(fd):
 def writef(file, data, path=DOWNL_PATH):
     if type(data) is str:
         data = data.encode('utf-8')
-    with openf(path + file, mode='wb') as fd:
+    if path is None:
+        path=DOWNL_PATH
+    # create directory tree if not exists
+    try:
+        os.makedirs(path)
+    except OSError as exc: # Guard against race condition
+        import errno
+        if exc.errno != errno.EEXIST:
+            raise
+    with openf(os.path.join(path, file), mode='wb') as fd:
         fd.write(data)
 
 

--- a/malsub/core/main.py
+++ b/malsub/core/main.py
@@ -13,7 +13,7 @@ pause = 0
 def run(arg, usage):
     def inarg():
         if (arg["--ipaddr"] or arg["--domain"] or arg["--appl"] or arg["--url"]) \
-                and not (arg["--download"] or arg["--find"] or arg["--find"]
+                and not (arg["--download"] or arg["--output"] or arg["--find"] or arg["--find"]
                          or arg["--report"] or arg["--submit"]):
             print(usage)
             exit(0)
@@ -213,7 +213,9 @@ def run(arg, usage):
                         kwarg = {"hash": j}
                     elif arg["--download"]:
                         fn = base.DOWNLOAD_FILE
-                        kwarg = {"hash": j}
+                        # Pass output dir if specified
+                        output_dir = arg["--output"] if arg["--output"] else None
+                        kwarg = {"hash": j, "directory": output_dir }
 
             if fn:  # and kwarg:
                 summ += [[i + 1, util.trunc(j), *exec(anserv, fn, kwarg)]]

--- a/malsub/core/main.py
+++ b/malsub/core/main.py
@@ -134,16 +134,28 @@ def run(arg, usage):
                     anserv[n].set_apikey(k)
             out.debug("apikey", obj=apikey)
 
-    if arg["--verbose"] == 1:
-        out.LEVEL = out.log.verb
-    elif arg["--verbose"] > 1:
-        out.LEVEL = out.log.debug
+    verbosity_levels_dict = {
+        0: out.log.quiet,
+        1: out.log.info,
+        2: out.log.verb,
+        3: out.log.debug
+    }
+
+    # docopt treats numeral values as strings
+    verbosity_level = int(arg["--verbose"])
+    
+    # default to log.info
+    out.LEVEL = verbosity_levels_dict.get(verbosity_level, out.log.info)
+        
     out.debug("arg", obj=arg)
 
     inarg()
     loadserv()
     loadkey()
-    ascii.banner()
+    
+    # Don't print banner on 'quiet' mode
+    if verbosity_level > 0:
+        ascii.banner()
 
     from malsub.common import frmt
     if arg["--servhelp"]:

--- a/malsub/core/meta.py
+++ b/malsub/core/meta.py
@@ -5,7 +5,7 @@ MALSUB_VERSION = "v1.2"
 MALSUB_URL = "https://github.com/diogo-fernan/malsub"
 
 DATA_PATH = "data" + SEP
-DOWNL_PATH = "downl" + SEP
+DOWNL_PATH = "downl"
 
 APIKEY_PATH = DATA_PATH + "apikey.yaml"
 SAMPLE_PATH = DATA_PATH + "e24b91383aa2547f23bfe2c500e2d2f4"

--- a/malsub/service/apivoid.py
+++ b/malsub/service/apivoid.py
@@ -30,7 +30,7 @@ class APIVoid(Service):
 
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     @Service.unsupported

--- a/malsub/service/avcaesar.py
+++ b/malsub/service/avcaesar.py
@@ -31,7 +31,7 @@ class AVCaesar(Service):
 
     # https://avcaesar.malware.lu/docs/api
 
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         self.api_dowf.fulluri = self.api_dowf.fullurl % hash.hash
         self.api_dowf.cookie = self.get_apikey()
         data, filename = request(self.api_dowf, bin=True)

--- a/malsub/service/base.py
+++ b/malsub/service/base.py
@@ -73,7 +73,7 @@ class Service(metaclass=MetaMix):
 
     def __init_subclass__(cls, **kwargs):
         from sys import modules
-        from os.path import basename
+        from os.path import basename, join
         for api in cls.__apiattr + cls.__attr:
             serv = f"class \"{cls.__name__}\" " \
                    f"<class '{cls.__module__}.{cls.__name__}'> in " \
@@ -95,7 +95,7 @@ class Service(metaclass=MetaMix):
         return NotImplemented
 
     @abstractmethod
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     @abstractmethod

--- a/malsub/service/haveibeenpwned.py
+++ b/malsub/service/haveibeenpwned.py
@@ -31,7 +31,7 @@ class HaveIbeenpwned(Service):
     # ?truncateResponse=true
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     @Service.unsupported

--- a/malsub/service/hybrid-analysis.py
+++ b/malsub/service/hybrid-analysis.py
@@ -32,7 +32,7 @@ class HybridAnalysis(Service):
     # https://www.hybrid-analysis.com/apikeys/info
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     def report_file(self, hash: Hash):

--- a/malsub/service/joesandbox.py
+++ b/malsub/service/joesandbox.py
@@ -28,7 +28,7 @@ class JoeSandbox(Service):
     api_quot = APISpec("POST", "https://jbxcloud.joesecurity.org", "/api/v2/account/info")
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     def report_file(self, hash: Hash):

--- a/malsub/service/malshare.py
+++ b/malsub/service/malshare.py
@@ -30,7 +30,7 @@ class MalShare(Service):
 
     # https://malshare.com/doc.php
 
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         self.api_dowf.param = {**self.get_apikey(), "action": "getfile",
                                "hash": hash.hash}
         data, filename = request(self.api_dowf, bin=True)

--- a/malsub/service/maltracker.py
+++ b/malsub/service/maltracker.py
@@ -32,7 +32,7 @@ class Maltracker(Service):
 
     # https://maltracker.net/static/docs/usage/api.html
 
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         self.api_dowf.fulluri = self.api_dowf.fullurl + hash.hash
         self.api_dowf.param = self.get_apikey()
         try:

--- a/malsub/service/malwr.py
+++ b/malsub/service/malwr.py
@@ -33,7 +33,7 @@ class Malwr(Service):
     # https://www.malwareviz.com/
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     @Service.unsupported

--- a/malsub/service/metadefender.py
+++ b/malsub/service/metadefender.py
@@ -32,7 +32,7 @@ class Metadefender(Service):
     # https://www.metadefender.com/public-api
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     def report_file(self, hash: Hash):

--- a/malsub/service/openphish.py
+++ b/malsub/service/openphish.py
@@ -31,7 +31,7 @@ class OpenPhish(Service):
 
     # https://openphish.com/
 
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         # self.api_dowf.fulluri = self.api_dowf.url + "/feed.txt"
         data, filename = request(self.api_dowf)
         rw.writef("openphish-community.txt", data)

--- a/malsub/service/pdf-examiner.py
+++ b/malsub/service/pdf-examiner.py
@@ -32,7 +32,7 @@ class PDFExaminer(Service):
     # https://github.com/mwtracker/pdfexaminer_tools
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     def report_file(self, hash: Hash):

--- a/malsub/service/phishtank.py
+++ b/malsub/service/phishtank.py
@@ -29,7 +29,7 @@ class PhishTank(Service):
 
     # http://www.phishtank.com/developer_info.php
 
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         self.api_dowf.fulluri = self.api_dowf.fullurl % self.get_apikey(
             key=True)
         data, filename = request(self.api_dowf, bin=True)

--- a/malsub/service/quicksand.py
+++ b/malsub/service/quicksand.py
@@ -32,7 +32,7 @@ class QuickSand(Service):
     # https://github.com/tylabs/quicksand_tools
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     def report_file(self, hash: Hash):

--- a/malsub/service/safebrowsing.py
+++ b/malsub/service/safebrowsing.py
@@ -32,7 +32,7 @@ class SafeBrowsing(Service):
     # https://developers.google.com/safe-browsing/
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     @Service.unsupported

--- a/malsub/service/threatcrowd.py
+++ b/malsub/service/threatcrowd.py
@@ -32,7 +32,7 @@ class ThreatCrowd(Service):
     # https://github.com/AlienVault-OTX/ApiV2
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     @Service.unsupported

--- a/malsub/service/threatstream.py
+++ b/malsub/service/threatstream.py
@@ -35,7 +35,7 @@ class ThreatStream(Service):
     limit = 0  # '0' means 1000
 
     @Service.unsupported
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         pass
 
     @Service.unsupported

--- a/malsub/service/virustotal.py
+++ b/malsub/service/virustotal.py
@@ -38,8 +38,9 @@ class VirusTotal(Service):
     # https://www.virustotal.com/en/documentation/private-api/
 
 
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         from requests.exceptions import HTTPError
+        from os import path
         self.api_dowf.param = {**self.get_apikey(), "hash": hash.hash}
         try:
             data, filename = request(self.api_dowf, bin=True)
@@ -49,7 +50,7 @@ class VirusTotal(Service):
             raise HTTPError(e)
         if not filename:
             filename = hash.hash
-        rw.writef(filename, data)
+        rw.writef(filename, data, path=directory)
         return f"downloaded \"{filename}\""
 
     def report_file(self, hash: Hash):

--- a/malsub/service/vxstream.py
+++ b/malsub/service/vxstream.py
@@ -64,7 +64,7 @@ class VxStream(Service):
         else:
             return False
 
-    def download_file(self, hash: Hash):
+    def download_file(self, hash: Hash, directory: str = None):
         if hash.alg == HASH_SHA256:
             data, flag = self.state(hash)
             if flag:


### PR DESCRIPTION
Hey! Thanks for a very nice tool :)
The following pull request improves and implements the following features:

**Better control for verbosity level**
 The new implementation honors 4 levels of verbosity:
   -  1 - Quiet - New, currently similar to Info but not printing the logo
   -  2 - Info - default
   -  3 - Verbose
   -  4 - Debug
 
 I updated the docs and the usage guide to reflect this change.
 I considered omitting any kind of non-error output in Quiet mode, what do you think?

Example:

```

# quiet mode
$ python malsub.py -v 0 -a vt -d 5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd
[+]    info Sun 22 Mar 2020 12:15:56.797073 +0000 UTC: "VirusTotal" -- "download_file" completed:
downloaded "5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd"

# info mode

$ python malsub.py -v 1 -a vt -d 5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd 

<LOGO: truncated>

   malsub v1.2
   https://github.com/diogo-fernan/malsub

[+]    info Sun 22 Mar 2020 12:16:02.538370 +0000 UTC: "VirusTotal" -- "download_file" completed:
downloaded "5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd"


# verbose mode

$ python malsub.py -v 2 -a vt -d 5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd  

<LOGO: truncated>

   malsub v1.2
   https://github.com/diogo-fernan/malsub

[+]    info Sun 22 Mar 2020 12:16:07.785904 +0000 UTC: "VirusTotal" -- "download_file" completed:
downloaded "5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd"
[*] verbose Sun 22 Mar 2020 12:16:07.786609 +0000 UTC: malsub finished with results:
+---+---------------------------------------------------------------------------+------------+
| # | input                                                                     | VirusTotal |
+---+---------------------------------------------------------------------------+------------+
| 1 | 5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd (sha256) | successful |



# debug mode

<... lots of lots of info ...>
```

----

**Support output directory for downloaded files**
Currently, users do not have a choice of where to save the downloaded files. To solve this, I created the `-O    --output <dir>` CLI arg which the user can use to specify a directory to save the downloaded files in.

Example:
```
$ python malsub.py -v 0 -a vt -d 
5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd 58ffd8200db69cfbc048921e18d79aa1adc894af34db3e1782e53beab3b2d98f -O /tmp
[+]    info Sun 22 Mar 2020 12:25:46.920896 +0000 UTC: "VirusTotal" -- "download_file" completed:
downloaded "5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd"
[+]    info Sun 22 Mar 2020 12:25:48.853046 +0000 UTC: "VirusTotal" -- "download_file" completed:
downloaded "58ffd8200db69cfbc048921e18d79aa1adc894af34db3e1782e53beab3b2d98f"

$ ls /tmp
 58ffd8200db69cfbc048921e18d79aa1adc894af34db3e1782e53beab3b2d98f
 5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd


```

