### PR TITLE
Create a basic module out of malsub

### DIFF
--- a/malsub.py
+++ b/malsub.py
@@ -72,7 +72,8 @@ from docopt import docopt, printable_usage
 
 from malsub.core import main
 
-exit(main.run(docopt(__doc__), printable_usage(__doc__)))
+if __name__ == '__main__':
+  exit(main.run(docopt(__doc__), printable_usage(__doc__)))
 
 
 # https://malwareconfig.com/api/

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,5 @@ setup(
     version="1.2",
     license="see LICENSE",
     packages=find_packages(),
-    scripts=["malsub"],
     url="https://github.com/diogo-fernan/malsub",
 )


### PR DESCRIPTION
This pull request improves the installation instructions and now it installs the module globally. This helps to use malsub as a module globally, and not only inside the cloned repository


```
import malsub
from malsub.service import serv as services

hashes = malsub.core.crypto.parse_hashl(
    "5f782447ff08ee2c36a5d3988dd4774674233f8ea0e1ad09dd766e842d785ddd",
    "58ffd8200db69cfbc048921e18d79aa1adc894af34db3e1782e53beab3b2d98f")

API_KEY = {'apikey': {'apikey': '...truncated...'}}

vt = services['vt']
vt.set_apikey(API_KEY)

for h in hashes:
    vt.download_file(h)
```