### PR TITLE
Remove unused services from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ The following services are currently included in *malsub*:
 * [VxStream](https://www.vxstream-sandbox.com/).
 * [JoeSandbox](https://www.joesandbox.com/).
 
-The following services were implemented, and declared deprecated due to service inactivity:
-
-* [AVCaesar](https://avcaesar.malware.lu/);
-* [malwr](https://malwr.com/);
-* [PDF Examiner](https://www.pdfexaminer.com/);
-* [QuickSand](https://www.quicksand.io/);
 
 Most of these services require API keys that are generated after registering an account in their respective websites, which need to be specified in the `apikey.yaml` file according to the given structure. Note that some of the already bundled services are limited in supported operations due to the fact that they were developed with free API keys. API keys associated with paid subscriptions are allowed to make additional calls not open to the public and may not be restricted by a given quota. Yet, *malsub* can process multiple input arguments and pause between requests as a workaround for cooldown periods.
 


### PR DESCRIPTION
PR #27 removed unused services from the repo. Since they won't be part of the code, and since the code is going through changes, I find it unnecessary to mention them at all. Therefore, I suggest removing the mentions for the services from the README. The current phrasing felt like the code for them is still there.

